### PR TITLE
Guard access to window global object

### DIFF
--- a/oauth-pkce/src/index.standalone.ts
+++ b/oauth-pkce/src/index.standalone.ts
@@ -29,7 +29,7 @@ function b64Uri(string: string) {
 
 function getPkce(length: number | undefined, callback: Callback): void {
   if (!length) length = 43;
-  const cryptoLib = window.msCrypto || window.crypto;
+  const cryptoLib = (typeof window !== 'undefined') && window.msCrypto || crypto;
 
   const verifier = b64Uri(
     Array.prototype.map
@@ -45,7 +45,7 @@ function getPkce(length: number | undefined, callback: Callback): void {
   }
   const digest = cryptoLib.subtle.digest('SHA-256', randomArray);
 
-  if (window.CryptoOperation) {
+  if ((typeof window !== 'undefined') && window.CryptoOperation) {
     (digest as typeof CryptoOperation).onerror = callback;
     (digest as typeof CryptoOperation).oncomplete = function (event: { target: { result: ArrayBuffer } }) {
       runCallback(callback, verifier, event.target.result);

--- a/oauth-pkce/src/index.ts
+++ b/oauth-pkce/src/index.ts
@@ -31,7 +31,7 @@ function b64Uri(string: string) {
 
 export default function getPkce(length: number | undefined, callback: Callback): void {
   if (!length) length = 43;
-  const cryptoLib = window.msCrypto || window.crypto;
+  const cryptoLib = (typeof window !== 'undefined') && window.msCrypto || crypto;
 
   const verifier = b64Uri(
     Array.prototype.map
@@ -47,7 +47,7 @@ export default function getPkce(length: number | undefined, callback: Callback):
   }
   const digest = cryptoLib.subtle.digest('SHA-256', randomArray);
 
-  if (window.CryptoOperation) {
+  if ((typeof window !== 'undefined') && window.CryptoOperation) {
     (digest as typeof CryptoOperation).onerror = callback;
     (digest as typeof CryptoOperation).oncomplete = function (event: { target: { result: ArrayBuffer } }) {
       runCallback(callback, verifier, event.target.result);


### PR DESCRIPTION
Hi @coolgk, thank you for this project!

Please could you consider this patch and release a new version if you approve.

This change adds support for using `oauth-pkce` in a Chrome extension background script or Web Worker, both of which have `crypto` available globally but don't use `window` as the global object.

Thanks!